### PR TITLE
Remove restriction

### DIFF
--- a/nasbench/controller.py
+++ b/nasbench/controller.py
@@ -54,12 +54,12 @@ class NAO(nn.Module):
     def forward(self, input_variable, input_len, target_variable=None):
         encoder_outputs, encoder_hidden, arch_emb, predict_value = self.encoder(input_variable, input_len)
         decoder_hidden = (arch_emb.unsqueeze(0), arch_emb.unsqueeze(0))
-        decoder_outputs, archs = self.decoder(target_variable, decoder_hidden, encoder_outputs)
+        decoder_outputs, archs = self.decoder(target_variable, input_len, decoder_hidden, encoder_outputs)
         return predict_value, decoder_outputs, archs
     
     def generate_new_arch(self, input_variable, input_len, predict_lambda=1, direction='-'):
         encoder_outputs, encoder_hidden, arch_emb, predict_value, new_encoder_outputs, new_arch_emb, new_predict_value = self.encoder.infer(
             input_variable, input_len, predict_lambda, direction=direction)
         new_encoder_hidden = (new_arch_emb.unsqueeze(0), new_arch_emb.unsqueeze(0))
-        decoder_outputs, new_archs = self.decoder(None, new_encoder_hidden, new_encoder_outputs)
+        decoder_outputs, new_archs = self.decoder(None, input_len, new_encoder_hidden, new_encoder_outputs)
         return new_archs, new_predict_value

--- a/nasbench/controller.py
+++ b/nasbench/controller.py
@@ -51,15 +51,15 @@ class NAO(nn.Module):
         self.encoder.rnn.flatten_parameters()
         self.decoder.rnn.flatten_parameters()
     
-    def forward(self, input_variable, target_variable=None):
-        encoder_outputs, encoder_hidden, arch_emb, predict_value = self.encoder(input_variable)
+    def forward(self, input_variable, input_len, target_variable=None):
+        encoder_outputs, encoder_hidden, arch_emb, predict_value = self.encoder(input_variable, input_len)
         decoder_hidden = (arch_emb.unsqueeze(0), arch_emb.unsqueeze(0))
         decoder_outputs, archs = self.decoder(target_variable, decoder_hidden, encoder_outputs)
         return predict_value, decoder_outputs, archs
     
-    def generate_new_arch(self, input_variable, predict_lambda=1, direction='-'):
+    def generate_new_arch(self, input_variable, input_len, predict_lambda=1, direction='-'):
         encoder_outputs, encoder_hidden, arch_emb, predict_value, new_encoder_outputs, new_arch_emb, new_predict_value = self.encoder.infer(
-            input_variable, predict_lambda, direction=direction)
+            input_variable, input_len, predict_lambda, direction=direction)
         new_encoder_hidden = (new_arch_emb.unsqueeze(0), new_arch_emb.unsqueeze(0))
         decoder_outputs, new_archs = self.decoder(None, new_encoder_hidden, new_encoder_outputs)
         return new_archs, new_predict_value

--- a/nasbench/runs/train_seminas.sh
+++ b/nasbench/runs/train_seminas.sh
@@ -2,9 +2,7 @@ cd ..
 export PYTHONPATH=.:$PYTHONPATH
 MODEL=seminas
 OUTPUT_DIR=outputs/$MODEL
-
+DATASET_DIR=home/dzzp/workspace/dataset/
 mkdir -p $OUTPUT_DIR
 
-python train_seminas.py \
-  --output_dir=$OUTPUT_DIR \
-  | tee $OUTPUT_DIR/log.txt
+CUDA_VISIBLE_DEVICES=1 python3 train_seminas.py --data=$DATASET_DIR --output_dir=$OUTPUT_DIR | tee $OUTPUT_DIR/log.txt

--- a/nasbench/train_seminas.py
+++ b/nasbench/train_seminas.py
@@ -61,13 +61,27 @@ def controller_train(train_queue, model, optimizer):
     nll = utils.AvgrageMeter()
     model.train()
     for step, sample in enumerate(train_queue):
-        encoder_input = utils.move_to_cuda(sample['encoder_input'])
-        encoder_target = utils.move_to_cuda(sample['encoder_target'])
-        decoder_input = utils.move_to_cuda(sample['decoder_input'])
-        decoder_target = utils.move_to_cuda(sample['decoder_target'])
+        encoder_input_unsorted = sample['encoder_input'].long() # shape maybe (batch size, max seq length, word length)
+        encoder_input_len_unsorted = sample['encoder_input_len']
+        encoder_target_unsorted = sample['encoder_target'].float()
+        decoder_input_unsorted = sample['decoder_input'].long()
+        decoder_target_unsorted = sample['decoder_target'].long()
+        
+        # sort input batch
+        encoder_input_len, sort_index = torch.sort(encoder_input_len_unsorted, 0, descending=True)
+        encoder_input_len = encoder_input_len.numpy().tolist()
+        encoder_input = torch.index_select(encoder_input_unsorted, 0, sort_index)
+        encoder_target = torch.index_select(encoder_target_unsorted, 0, sort_index)
+        decoder_input = torch.index_select(decoder_input_unsorted, 0, sort_index)
+        decoder_target = torch.index_select(decoder_target_unsorted, 0, sort_index)
+
+        encoder_input = utils.move_to_cuda(encoder_input) # shape maybe (batch size, max seq length, word length)
+        encoder_target = utils.move_to_cuda(encoder_target)
+        decoder_input = utils.move_to_cuda(decoder_input)
+        decoder_target = utils.move_to_cuda(decoder_target)
 
         optimizer.zero_grad()
-        predict_value, log_prob, arch = model(encoder_input, decoder_input)
+        predict_value, log_prob, arch = model(encoder_input, encoder_input_len, decoder_input)
         loss_1 = F.mse_loss(predict_value.squeeze(), encoder_target.squeeze())
         loss_2 = F.nll_loss(log_prob.contiguous().view(-1, log_prob.size(-1)), decoder_target.view(-1))
         loss = args.trade_off * loss_1 + (1 - args.trade_off) * loss_2
@@ -88,9 +102,17 @@ def controller_infer(queue, model, step, direction='+'):
     new_predict_values = []
     model.eval()
     for i, sample in enumerate(queue):
-        encoder_input = utils.move_to_cuda(sample['encoder_input'])
+        encoder_input_unsorted = sample['encoder_input'].long() # shape maybe (batch size, max seq length, word length)
+        encoder_input_len_unsorted = sample['encoder_input_len']
+        # sort input batch
+        encoder_input_len, sort_index = torch.sort(encoder_input_len_unsorted, 0, descending=True)
+        encoder_input_len = encoder_input_len.numpy().tolist()
+        encoder_input = torch.index_select(encoder_input_unsorted, 0, sort_index)
+        # move to gpu
+        encoder_input = utils.move_to_cuda(encoder_input)
+        
         model.zero_grad()
-        new_arch, new_predict_value = model.generate_new_arch(encoder_input, step, direction=direction)
+        new_arch, new_predict_value = model.generate_new_arch(encoder_input, encoder_input_len, step, direction=direction)
         new_arch_list.extend(new_arch.data.squeeze().tolist())
         new_predict_values.extend(new_predict_value.data.squeeze().tolist())
     return new_arch_list, new_predict_values
@@ -122,8 +144,16 @@ def generate_synthetic_controller_data(nasbench, model, base_arch=None, random_a
         with torch.no_grad():
             model.eval()
             for sample in controller_synthetic_queue:
-                encoder_input = sample['encoder_input'].cuda()
-                _, _, _, predict_value = model.encoder(encoder_input)
+                encoder_input_unsorted = sample['encoder_input'].long() # shape maybe (batch size, max seq length, word length)
+                encoder_input_len_unsorted = sample['encoder_input_len']
+                # sort input batch
+                encoder_input_len, sort_index = torch.sort(encoder_input_len_unsorted, 0, descending=True)
+                encoder_input_len = encoder_input_len.numpy().tolist()
+                encoder_input = torch.index_select(encoder_input_unsorted, 0, sort_index)
+                # move to gpu
+                encoder_input = utils.move_to_cuda(encoder_input)
+                
+                _, _, _, predict_value = model.encoder(encoder_input, encoder_input_len)
                 random_synthetic_target += predict_value.data.squeeze().tolist()
         assert len(random_synthetic_input) == len(random_synthetic_target)
     synthetic_input = random_synthetic_input
@@ -148,7 +178,7 @@ def main():
 
     args.source_length = args.encoder_length = args.decoder_length = (args.nodes + 2) * (args.nodes - 1) // 2
 
-    nasbench = api.NASBench(os.path.join(args.data, 'nasbench_full.tfrecord'))
+    nasbench = api.NASBench(os.path.join(args.data, 'nasbench_only108.tfrecord'))
     
     controller = NAO(
         args.encoder_layers,
@@ -174,8 +204,8 @@ def main():
         logging.info('Iteration {}'.format(i+1))
         if not child_arch_pool_valid_acc:
             for arch in child_arch_pool:
-                data = nasbench.query(arch)
-                child_arch_pool_valid_acc.append(data['validation_accuracy'])
+                val_acc = nasbench.query(arch, option='valid')
+                child_arch_pool_valid_acc.append(val_acc)
 
         arch_pool += child_arch_pool
         arch_pool_valid_acc += child_arch_pool_valid_acc
@@ -200,8 +230,7 @@ def main():
                 print('Architecutre connection:{}'.format(arch_pool[arch_index].matrix))
                 print('Architecture operations:{}'.format(arch_pool[arch_index].ops))
                 print('Valid accuracy:{}'.format(arch_pool_valid_acc[arch_index]))
-                fs, cs = nasbench.get_metrics_from_spec(arch_pool[arch_index])
-                test_acc = np.mean([cs[108][j]['final_test_accuracy'] for j in range(3)])
+                test_acc = nasbench.query(arch_pool[arch_index], option='test')
                 print('Mean test accuracy:{}'.format(test_acc))
             break
 

--- a/nasbench/train_seminas.py
+++ b/nasbench/train_seminas.py
@@ -277,7 +277,7 @@ def main():
             for seq in new_seq:
                 matrix, ops = utils.convert_seq_to_arch(seq)
                 arch = api.ModelSpec(matrix=matrix, ops=ops)
-                if nasbench.is_valid(arch) and len(arch.ops) == 7 and seq not in train_encoder_input and seq not in new_seqs:
+                if nasbench.is_valid(arch) and seq not in train_encoder_input and seq not in new_seqs:
                     new_archs.append(arch)
                     new_seqs.append(seq)
                 if len(new_seqs) >= args.new_arch:

--- a/nasbench/train_seminas.py
+++ b/nasbench/train_seminas.py
@@ -275,7 +275,7 @@ def main():
             logging.info('Generate new architectures with step size %d', predict_step_size)
             new_seq, new_perfs = controller_infer(controller_infer_queue, controller, predict_step_size, direction='+')
             for seq in new_seq:
-                matrix, ops = utils.convert_seq_to_arch(seq)
+                matrix, ops = utils.convert_seq_to_arch(seq, nasbench.search_space)
                 arch = api.ModelSpec(matrix=matrix, ops=ops)
                 if nasbench.is_valid(arch) and seq not in train_encoder_input and seq not in new_seqs:
                     new_archs.append(arch)

--- a/nasbench/utils.py
+++ b/nasbench/utils.py
@@ -86,7 +86,7 @@ class ControllerDataset(torch.utils.data.Dataset):
     
     def __getitem__(self, index):
         encoder_input = self.inputs[index] + [0 for _ in range(self.max_len - len(self.inputs[index]))] # fix length as max_len
-        len_encoder_input = self.len_inputs[index]
+        len_input = self.len_inputs[index]
         encoder_target = None
         if self.targets is not None:
             encoder_target = [self.targets[index]]
@@ -94,16 +94,16 @@ class ControllerDataset(torch.utils.data.Dataset):
             decoder_input = [self.sos_id] + encoder_input[:-1]
             sample = {
                 'encoder_input': np.array(encoder_input, dtype=np.int64),
-                'encoder_input_len': len_encoder_input,
                 'encoder_target': np.array(encoder_target, dtype=np.float64),
                 'decoder_input': np.array(decoder_input, dtype=np.int64),
                 'decoder_target': np.array(encoder_input, dtype=np.int64),
+                'input_len': len_input,
             }
         else:
             sample = {
                 'encoder_input': np.array(encoder_input, dtype=np.int64),
-                'encoder_input_len': len_encoder_input,
                 'decoder_target': np.array(encoder_input, dtype=np.int64),
+                'input_len': len_input,
             }
             if encoder_target is not None:
                 sample['encoder_target'] = np.array(encoder_target, dtype=np.float64)


### PR DESCRIPTION
### **Remove restriction of length of seq(=7)**

* **Before pass input to the Encoder or Decoder** (def controller_train / controller_infer / generate_synthetic_controller_data):

sort seqs by length of seq in one batch. 

* **Decoder**: 

pack_padded_sequence before rnn : make rnn ignore the inputs outside the length of the seq.

pad_packed_seqeunce after rnn : restore original shape.

pass mask to attention model : Because the length of seqs can be different each other in one batch, use mask to ignore out-of-length.

* **Encoder**:

pack_padded_sequence before rnn :  make rnn ignore the inputs outside the length of the seq.

pad_packed_seqeunce after rnn : restore original shape

* **DataLoader**: 

add 'input_len' (list of length of seqs in one batch) -> pass to the encoder / decoder

* compatible with our nasbench api